### PR TITLE
Spoof window size to enforce compact layout.

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -408,6 +408,17 @@ const checkBackgroundColorDark = () => {
     }
 }
 
+function spoofWindowSize() {
+    console.log("Monkey patching 'window' and 'document' properties.");
+    const width = Math.min(document.documentElement.offsetWidth || 800, 800)
+    if (window.innerWidth === width && document.documentElement.clientWidth === width) {
+        return
+    }
+    window.__defineGetter__('innerWidth', () => width);
+    document.documentElement.__defineGetter__('clientWidth', () => width)
+    window.dispatchEvent(new Event('resize'));
+}
+
 const run = () => getContainer()
     .then(container => {
 
@@ -448,6 +459,11 @@ let feedHeight = 2500;
 let container_top = 0;
 const showMoreIncrement = 2500;
 const currentPage = getCurrentPage();
+
+window.addEventListener('load', spoofWindowSize)
+window.addEventListener('resize', spoofWindowSize)
+document.addEventListener('visibilitychange', spoofWindowSize)
+spoofWindowSize();
 
 // a quick switch to turn on/off the content script for demo purpose
 chrome.storage.local.get(["state"]).then((result) => {

--- a/manifest.json
+++ b/manifest.json
@@ -12,9 +12,10 @@
   ],
   "content_scripts": [
     {
+      "world": "MAIN",
       "matches": ["*://twitter.com/*","*://www.facebook.com/*","*://www.youtube.com/*","*://www.linkedin.com/*"],
       "css": ["finite_scroll_style.css"],
-      "js": ["jquery-3.4.1.slim.min.js","content-script.js"]
+      "js": ["jquery-3.4.1.slim.min.js"]
     }
   ],
   "action": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -41,10 +41,11 @@ function updateState(changes, area) {
   } else {
     chrome.scripting.registerContentScripts([{
         id: extName,
+        world: 'MAIN', /* Necessary for monkey patching the 'window' object. */
         matches: supportedSites.map((elem) => {
           return "https://" + elem + "/*"
         }),
-        js: ["script.js"],
+        js: ["content-script.js"],
     }]).then(() => console.log("Registered content script."));
     chrome.action.setIcon({path: {"128": "icons/purpose-mode-on.png"}});
     chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {

--- a/ui.js
+++ b/ui.js
@@ -32,7 +32,7 @@ async function onExtEnable() {
     target: {
       tabId: tab[0].id
     },
-    files: ["script.js"]
+    files: ["content-script.js"]
   });
   console.log("Injected content script into: " + url);
 }


### PR DESCRIPTION
This commit makes the following changes:

* Add a function to the content script that monkey patches some properties of the 'document' and 'window' object.  This tricks sites into thinking that they're running on a small screen, which triggers a compact (and less distracting) layout.

* Remove the content script from the manifest.  Instead, the service worker only injects the content script when necessary.  This has the advantage that the content script doesn't need to worry about Purpose Mode being turned on or off.

* Replace script.js with content-script.js.  Best to only maintain a single content script.