### PR TITLE
Make site-specific toggles collapsibles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jquery": "^3.7.0",
     "plasmo": "0.77.5",
     "react": "18.2.0",
+    "react-collapsed": "^4.0.2",
     "react-dom": "18.2.0",
     "use-chrome-storage": "^1.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   react:
     specifier: 18.2.0
     version: 18.2.0
+  react-collapsed:
+    specifier: ^4.0.2
+    version: 4.0.2(react-dom@18.2.0)(react@18.2.0)
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
@@ -4771,6 +4774,17 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
+  /react-collapsed@4.0.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-mzGhppOLzW3PGtU+RlSYPANpShYd5wt6LdFWnDgHy/asyIfQT8BHDognr5sYFPouXiHPwGWUtQ6ZfI5jd7bU6Q==}
+    peerDependencies:
+      react: ^16.9.0 || ^17 || ^18
+      react-dom: ^16.9.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tiny-warning: 1.0.3
+    dev: false
+
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -5216,6 +5230,10 @@ packages:
 
   /timsort@0.3.0:
     resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
+    dev: false
+
+  /tiny-warning@1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
 
   /tmp@0.0.33:


### PR DESCRIPTION
This PR uses the react-collapsed module to implement collapsible toggle groups.  For convenience, the code automatically expands the toggle group of the site the user is currently on.